### PR TITLE
Add basic SAM platform prototype

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,60 @@
+from flask import Flask, request, jsonify
+from database import init_db, db
+from models import Account, Stakeholder, Product, AccountProduct, Opportunity
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['DATABASE_URI'] = 'postgresql://sam:sam@db:5432/sam'
+    init_db(app)
+
+    @app.route('/accounts', methods=['POST'])
+    def create_account():
+        data = request.json
+        account = Account(name=data['name'], notes=data.get('notes',''))
+        db.session.add(account)
+        db.session.commit()
+        return jsonify({'id': account.id, 'name': account.name}), 201
+
+    @app.route('/accounts', methods=['GET'])
+    def list_accounts():
+        accounts = Account.query.all()
+        return jsonify([{'id': a.id, 'name': a.name, 'health_score': a.health_score} for a in accounts])
+
+    @app.route('/accounts/<int:account_id>/stakeholders', methods=['POST'])
+    def add_stakeholder(account_id):
+        data = request.json
+        sh = Stakeholder(account_id=account_id, name=data['name'], role=data.get('role'),
+                         influence=data.get('influence'), strength=data.get('strength'))
+        db.session.add(sh)
+        db.session.commit()
+        return jsonify({'id': sh.id}), 201
+
+    @app.route('/accounts/<int:account_id>/stakeholders', methods=['GET'])
+    def list_stakeholders(account_id):
+        stakeholders = Stakeholder.query.filter_by(account_id=account_id).all()
+        return jsonify([{'id': s.id, 'name': s.name, 'role': s.role,
+                        'influence': s.influence, 'strength': s.strength} for s in stakeholders])
+
+    @app.route('/accounts/<int:account_id>/white_space', methods=['GET'])
+    def white_space(account_id):
+        products = Product.query.all()
+        matrix = []
+        for product in products:
+            ap = AccountProduct.query.filter_by(account_id=account_id, product_id=product.id).first()
+            matrix.append({'product': product.name, 'adopted': bool(ap and ap.adopted)})
+        return jsonify(matrix)
+
+    @app.route('/accounts/<int:account_id>/ai_insights', methods=['GET'])
+    def ai_insights(account_id):
+        # Placeholder for AI engine
+        account = Account.query.get_or_404(account_id)
+        insight = f"Consider engaging more stakeholders for {account.name}."
+        return jsonify({'next_best_action': insight})
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(host='0.0.0.0')

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,15 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask import Flask
+
+# Initialize SQLAlchemy without app, to use application factory
+
+db = SQLAlchemy()
+
+
+def init_db(app: Flask):
+    app.config['SQLALCHEMY_DATABASE_URI'] = app.config.get(
+        'DATABASE_URI', 'postgresql://sam:sam@db:5432/sam')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from database import db
+
+class Account(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    notes = db.Column(db.Text, default='')
+    health_score = db.Column(db.Integer, default=0)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Stakeholder(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)
+    name = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(64))
+    influence = db.Column(db.String(32))
+    strength = db.Column(db.String(32))
+
+    account = db.relationship('Account', backref=db.backref('stakeholders', lazy=True))
+
+class Product(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False, unique=True)
+
+class AccountProduct(db.Model):
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), primary_key=True)
+    adopted = db.Column(db.Boolean, default=False)
+
+    account = db.relationship('Account', backref=db.backref('account_products', lazy=True))
+    product = db.relationship('Product')
+
+class Opportunity(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)
+    name = db.Column(db.String(128))
+    stage = db.Column(db.String(64))
+    score = db.Column(db.Integer, default=0)
+
+    account = db.relationship('Account', backref=db.backref('opportunities', lazy=True))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.0.2
+psycopg2-binary==2.9.6
+redis==4.6.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: sam
+      POSTGRES_PASSWORD: sam
+      POSTGRES_DB: sam
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend:/app
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+      - redis
+
+  frontend:
+    build: ./frontend
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install --legacy-peer-deps
+COPY . .
+CMD ["npm", "start"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sam-frontend",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sam-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^5.0.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SAM Platform</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const App = () => {
+  return <h1>Strategic Account Management Platform</h1>;
+};
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,16 @@
+# Strategic Account Management Platform
 
+This repository contains a minimal prototype of a Strategic Account Management (SAM) tool. The stack uses a Flask backend with a React/TypeScript frontend. PostgreSQL and Redis are included via Docker Compose.
+
+## Running locally
+
+1. Ensure Docker and Docker Compose are installed.
+2. From the repository root, run:
+   ```bash
+   docker compose up --build
+   ```
+3. The backend will be available at `http://localhost:5000` and the frontend at `http://localhost:3000`.
+
+## Development
+
+The backend code lives under `./backend` and the frontend under `./frontend`.


### PR DESCRIPTION
## Summary
- implement Flask backend with sample endpoints for accounts, stakeholders, white space matrix, and AI insights
- add minimal React/TypeScript frontend
- containerize services with Docker Compose, Postgres, and Redis
- document local development instructions

## Testing
- `python -m py_compile backend/app.py backend/database.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_686864f6725083309d2b9f0417f44ce2